### PR TITLE
Rename StaticDouble to Doppel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Bag2\StaticDouble
+# Bag2\Doppel
 
 
-**StaticDouble** is a PHP mocking framework for static methods.
+**Doppel** is a PHP mocking framework for static methods.
 
 ## Example
 
@@ -16,12 +16,12 @@ class Vehicle {
 
 echo Vehicle::horn(), PHP_EOL; // Beep!
 
-$static_double_manager = (new Bag2\StaticDouble\Factory)->create();
-$static_double_manager->add('Vehicle::horn')->andReturn('Boo!');
+$doppel = (new Bag2\Doppel\Factory)->create();
+$doppel->add('Vehicle::horn')->andReturn('Boo!');
 
 echo Vehicle::horn(), PHP_EOL; // Boo!
 
-$static_double_manager->finalize();
+$doppel->finalize();
 
 echo Vehicle::horn(), PHP_EOL; // Beep!
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,15 @@
 {
-    "name": "bag2/staticdouble",
+    "name": "bag2/doppel",
     "description": "Test double implementation for static methods",
     "license": "MPL-2.0",
     "autoload": {
         "psr-4": {
-            "Bag2\\StaticDouble\\": "src/"
+            "Bag2\\Doppel\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Bag2\\StaticDouble\\": "tests/"
+            "Bag2\\Doppel\\": "tests/"
         }
     },
     "require": {

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://www.phpdoc.org"
     xsi:noNamespaceSchemaLocation="data/xsd/phpdoc.xsd">
-  <title>Bag2&#x5C;StaticDouble</title>
+  <title>Bag2&#x5C;Doppel</title>
   <paths>
     <output>docs/api</output>
   </paths>
@@ -24,7 +24,7 @@
       <extensions>
         <extension>php</extension>
       </extensions>
-      <default-package-name>Bag2&#x5C;StaticDouble</default-package-name>
+      <default-package-name>Bag2&#x5C;Doppel</default-package-name>
     </api>
     <guide>
       <source dsn=".">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
     colors="true"
     verbose="false">
   <testsuites>
-    <testsuite name="Bag2\StaticDouble">
+    <testsuite name="Bag2\Doppel">
       <directory>tests/</directory>
       <exclude>tests/files/</exclude>
     </testsuite>

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Bag2\StaticDouble;
+namespace Bag2\Doppel;
 
-use Bag2\StaticDouble\Replacer\ReplacerFactory;
+use Bag2\Doppel\Replacer\ReplacerFactory;
 
 /**
  * A factory class of Static TestDouble manager

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Bag2\StaticDouble;
+namespace Bag2\Doppel;
 
-use Bag2\StaticDouble\Util\CallableHelper;
+use Bag2\Doppel\Util\CallableHelper;
 use function debug_backtrace;
 use const DEBUG_BACKTRACE_IGNORE_ARGS;
 use Generator;

--- a/src/Replacer.php
+++ b/src/Replacer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Bag2\StaticDouble;
+namespace Bag2\Doppel;
 
 use Closure;
 

--- a/src/Replacer/ReplacerFactory.php
+++ b/src/Replacer/ReplacerFactory.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Bag2\StaticDouble\Replacer;
+namespace Bag2\Doppel\Replacer;
 
 use function array_pop;
-use Bag2\StaticDouble\Replacer;
+use Bag2\Doppel\Replacer;
 use function implode;
 use LogicException;
 

--- a/src/Replacer/Runkit7.php
+++ b/src/Replacer/Runkit7.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Bag2\StaticDouble\Replacer;
+namespace Bag2\Doppel\Replacer;
 
-use Bag2\StaticDouble\Replacer;
-use Bag2\StaticDouble\Util\CallableHelper;
+use Bag2\Doppel\Replacer;
+use Bag2\Doppel\Util\CallableHelper;
 use Closure;
 use function extension_loaded;
 use function runkit7_function_add;

--- a/src/Replacer/Uopz.php
+++ b/src/Replacer/Uopz.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Bag2\StaticDouble\Replacer;
+namespace Bag2\Doppel\Replacer;
 
-use Bag2\StaticDouble\Replacer;
+use Bag2\Doppel\Replacer;
 use Closure;
 use function extension_loaded;
 use function uopz_set_return;

--- a/src/TestDouble.php
+++ b/src/TestDouble.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Bag2\StaticDouble;
+namespace Bag2\Doppel;
 
 use LogicException;
 

--- a/src/Util/CallableHelper.php
+++ b/src/Util/CallableHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Bag2\StaticDouble\Util;
+namespace Bag2\Doppel\Util;
 
 use function explode;
 use function is_array;

--- a/tests/Replacer/ReplacerFactoryTest.php
+++ b/tests/Replacer/ReplacerFactoryTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Bag2\StaticDouble\Replacer;
+namespace Bag2\Doppel\Replacer;
 
-use Bag2\StaticDouble\TestCase;
+use Bag2\Doppel\TestCase;
 use LogicException;
 
 final class ReplacerFactoryTest extends TestCase

--- a/tests/Replacer/Runkit7Test.php
+++ b/tests/Replacer/Runkit7Test.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Bag2\StaticDouble\Replacer;
+namespace Bag2\Doppel\Replacer;
 
-use Bag2\StaticDouble\TestCase;
-use Bag2\StaticDouble\Util\CallableHelper;
+use Bag2\Doppel\TestCase;
+use Bag2\Doppel\Util\CallableHelper;
 use LogicException;
 
 final class Runkit7Test extends TestCase

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Bag2\StaticDouble;
+namespace Bag2\Doppel;
 
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
 /**
- * Base TestCase for Bag2\StaticDouble
+ * Base TestCase for Bag2\Doppel
  *
  * @author USAMI Kenta <tadsan@zonu.me>
  * @copyright 2020 Baguette HQ

--- a/tests/Util/CallableHelperTest.php
+++ b/tests/Util/CallableHelperTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Bag2\StaticDouble\Util;
+namespace Bag2\Doppel\Util;
 
-use Bag2\StaticDouble\TestCase;
-use Bag2\StaticDouble\Util\CallableHelper;
+use Bag2\Doppel\TestCase;
+use Bag2\Doppel\Util\CallableHelper;
 use LogicException;
 
 final class Runkit7Test extends TestCase


### PR DESCRIPTION
“Static Double” was a composite name of [StaticMock](https://github.com/tototoshi/staticmock) and [test double](https://en.wikipedia.org/wiki/Test_double). However, emphasizing **“Static”** does not correctly reflect the reality of this package, so renaming was considered.

“Doppel” is the German word for “double” in English. This word is reminiscent of [Doppelgänger](https://en.wikipedia.org/wiki/Doppelg%C3%A4nger) and is related to the nature of test doubles, which replace methods of a class with a substitute.